### PR TITLE
create:パンくず設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ gem 'carrierwave', '~> 3.0'
 gem 'fog-aws'
 
 gem 'dotenv-rails'
+
+gem "gretel"
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,9 @@ GEM
     formatador (1.1.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    gretel (5.0.1)
+      actionview (>= 6.1)
+      railties (>= 6.1)
     hashie (5.0.0)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
@@ -380,6 +383,7 @@ DEPENDENCIES
   debug
   dotenv-rails
   fog-aws
+  gretel
   i18n
   jbuilder
   jsbundling-rails

--- a/app/controllers/concerns/breadcrumbs_concern.rb
+++ b/app/controllers/concerns/breadcrumbs_concern.rb
@@ -1,0 +1,39 @@
+module BreadcrumbsConcern
+  extend ActiveSupport::Concern
+
+  def set_breadcrumbs_index
+    case request.referer
+    when new_menu_url
+      @breadcrumbs = :menus_path_new
+    else 
+      @breadcrumbs = :menus_path
+    end
+  end
+
+  def set_breadcrumbs_edit
+    case request.referer
+    when menus_url
+      @breadcrumbs = :edit_menu_path
+    else 
+      @breadcrumbs = :edit_menu_path_show
+    end
+  end
+
+  def referer_is_search_menus?
+    request.referer.include?("/menus/search")
+  end
+
+  def set_breadcrumbs_show
+    if referer_is_search_menus?
+      @breadcrumbs = :menu_path_search # 検索結果
+    elsif request.referer == suggest_menus_url
+      @breadcrumbs = :menu_path_suggest # 献立提案
+    elsif request.referer == edit_menu_url
+      @breadcrumbs = :menu_path_edit # 献立編集
+    elsif request.referer == likes_menus_url
+      @breadcrumbs = :menu_path_like # お気に入り一覧
+    else
+      @breadcrumbs = :menu_path_menus # 献立一覧
+    end
+  end
+end

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -1,10 +1,12 @@
 class MenusController < ApplicationController
+  include BreadcrumbsConcern
   skip_before_action :require_login, only: %i[top suggest show search]
 
   def top; end
 
   def index
     @menus = Menu.includes(:user).where(user_id: current_user.id)
+    set_breadcrumbs_index
   end
 
   def new
@@ -13,10 +15,12 @@ class MenusController < ApplicationController
 
   def show
     @menu = Menu.find(params[:id])
+    set_breadcrumbs_show
   end
 
   def edit
     @menu = current_user.menus.find(params[:id])
+    set_breadcrumbs_edit
   end
 
   def create

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,9 @@
       <% end %>
       <%= render 'shared/flash_message', class: 'flash_message' %>
       <div class="content">
+        <% if logged_in? %>
+          <%= breadcrumbs separator: " > " %>
+        <% end %>
         <%= yield %>
       </div>
       <%= render 'shared/footer' %>

--- a/app/views/menus/edit.html.erb
+++ b/app/views/menus/edit.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:title, t('menus.edit.title')) %>
+<% breadcrumb @breadcrumbs %>
 <div class="container">
   <div class="row">
     <%= render 'form', menu: @menu, title_key: 'edit' %>

--- a/app/views/menus/index.html.erb
+++ b/app/views/menus/index.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:title, t('.title')) %>
+<% breadcrumb @breadcrumbs %>
 <div class="container pt-3">
   <!-- 掲示板一覧 -->
   <div class="row">

--- a/app/views/menus/likes.html.erb
+++ b/app/views/menus/likes.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:title, t('.title')) %>
+<% breadcrumb :likes_menus_path %>
 <div class="container pt-3">
   <!-- 掲示板一覧 -->
   <div class="row">

--- a/app/views/menus/new.html.erb
+++ b/app/views/menus/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:title, t('menus.new.title')) %>
+<%breadcrumb :new_menu_path %>
 <div class="container">
   <div class="row">
     <%= render 'form', menu: @menu, title_key: 'new' %>

--- a/app/views/menus/search.html.erb
+++ b/app/views/menus/search.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:title, t('.title')) %>
+<% breadcrumb :search_menus_path %>
 <div class="container">
   <div class="top-suggest">
     <% if @search_results %>

--- a/app/views/menus/show.html.erb
+++ b/app/views/menus/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:title, t('.title')) %>
+<% breadcrumb @breadcrumbs %>
 <div class="container pt-5">
   <div class="menu-detail-board">
     <article class="card">

--- a/app/views/menus/suggest.html.erb
+++ b/app/views/menus/suggest.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:title, t('.title')) %>
+<% breadcrumb :suggest_menus %>
 <div class="container">
   <div class="top-suggest">
     <h2><%= t('.today_menu_is') %></h2>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,116 @@
+crumb :root do
+  link "Home", root_path
+end
+# homeから遷移
+crumb :suggest_menus do
+  link '献立提案', suggest_menus_path
+  parent :root
+end
+
+crumb :search_menus_path do
+  link '検索結果', search_menus_path
+  parent :root
+end
+
+crumb :login_path do
+  link 'ログイン', login_path
+  parent :root
+end
+
+crumb :new_user_path do
+  link '会員登録', new_user_path
+  parent :root
+end
+
+crumb :new_menu_path do 
+  link '献立投稿', new_menu_path
+  parent :root
+end
+
+crumb :likes_menus_path do
+  link 'お気に入り一覧', likes_menus_path
+  parent :root
+end
+
+crumb :privacy_path do
+  link 'プライバシーポリシー', privacy_path
+  parent :root
+end
+
+crumb :terms_path do
+  link '利用規約', terms_path
+  parent :root
+end
+
+# 投稿編集
+crumb :edit_menu_path do
+  link '献立編集', edit_menu_path
+  parent :menus_path
+end
+
+crumb :edit_menu_path_show do
+  link '献立編集', edit_menu_path
+  parent :menu_path_menus
+end
+
+# 投稿一覧
+crumb :menus_path do
+  link '投稿一覧', menus_path
+  parent :root
+end
+
+crumb :menus_path_new do
+  link '投稿一覧', menus_path
+  parent :new_menu_path
+end
+
+# 献立詳細
+crumb :menu_path_search do
+  link '献立詳細', menu_path
+  parent :search_menus_path # 検索結果
+end
+
+crumb :menu_path_suggest do
+  link '献立詳細', menu_path
+  parent :suggest_menus # 献立提案
+end
+
+crumb :menu_path_edit do
+  link '献立詳細', menu_path
+  parent :edit_menu_path  # 献立編集
+end
+
+crumb :menu_path_menus do
+  link '献立詳細', menu_path
+  parent :menus_path # 献立一覧
+end
+
+crumb :menu_path_like do
+  link '献立詳細', menu_path
+  parent :likes_menus_path # お気に入り一覧
+end
+
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).


### PR DESCRIPTION
# 概要
closes #24 

gem gretelを用いてパンくず設定を行いました。
献立詳細、献立一覧、献立編集は遷移元に応じて親パンくずが変わるようにしました。

パンくず設定はログインしたユーザーのみに表示されます。