### PR TITLE
update:お気に入りボタンの非同期通信

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,13 +1,11 @@
 class LikesController < ApplicationController
   def create
-    menu = Menu.find(params[:menu_id])
-    current_user.likemenu(menu)
-    redirect_to likes_menus_path
+    @menu = Menu.find(params[:menu_id])
+    current_user.likemenu(@menu)
   end
 
   def destroy
-    menu = current_user.likes.find(params[:id]).menu
-    current_user.unlikemenu(menu)
-    redirect_to likes_menus_path, status: :see_other
+    @menu = current_user.likes.find(params[:id]).menu
+    current_user.unlikemenu(@menu)
   end
 end

--- a/app/views/likes/create.turbo_stream.erb
+++ b/app/views/likes/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "like-button-for-board-#{@menu.id}" do %>
+  <%= render 'menus/unlike_button', menu: @menu %>
+<% end %>

--- a/app/views/likes/destroy.turbo_stream.erb
+++ b/app/views/likes/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "unlike-button-for-board-#{@menu.id}" do %>
+  <%= render 'menus/like_button', menu: @menu %>
+<% end %>


### PR DESCRIPTION
# 概要
closes #26 
closes #27 

お気に入りボタンを非同期通信で行えるようにしました。
gem turbo-railsを用いています。