### PR TITLE
create:line友だち追加ページ

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y curl libjemalloc2 libvips postgresql-client && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
+# COPY crontab /etc/cron.d/my-cron-job
+
+# RUN chmod 0644 /etc/cron.d/my-cron-job && \
+    # crontab /etc/cron.d/my-cron-job
+
 # Set production environment
 ENV RAILS_ENV="production" \
     BUNDLE_DEPLOYMENT="1" \
@@ -81,3 +86,4 @@ ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 # Start the server by default, this can be overwritten at runtime
 EXPOSE 3000
 CMD ["./bin/rails", "server"]
+# CMD service cron start && ./bin/rails server

--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,8 @@ gem 'omniauth-auth0'
 gem 'omniauth-line'
 
 gem 'omniauth-rails_csrf_protection'
+
+gem 'line-bot-api'
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,6 +205,7 @@ GEM
       letter_opener (~> 1.9)
       railties (>= 6.1)
       rexml
+    line-bot-api (1.29.0)
     logger (1.6.1)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -472,6 +473,7 @@ DEPENDENCIES
   jsbundling-rails
   kaminari
   letter_opener_web (~> 3.0)
+  line-bot-api
   meta-tags
   omniauth-auth0
   omniauth-line

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -7,3 +7,4 @@
 @import 'suggest';
 @import 'menu';
 @import 'edit_profile';
+@import 'line';

--- a/app/assets/stylesheets/line.scss
+++ b/app/assets/stylesheets/line.scss
@@ -1,0 +1,75 @@
+.line-profile-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    padding: 2rem;
+    box-sizing: border-box;
+    overflow-y: auto;
+}
+
+.line-profile-edit-form {
+    background: rgba(255, 255, 255, 1);
+    padding: 4rem;
+    border-radius: 8px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+    width: 95%;
+    max-width: 800px;
+    margin: auto;
+    text-align: center;
+}
+
+.line-top-explanation h3 {
+    color: #007bff;
+    font-size: 2rem;
+    margin-bottom: 2rem;
+    text-align: center;
+}
+
+.line-navbar-login {
+    display: inline-flex;
+    align-items: center;
+    background-color: #00C300; /* LINEグリーン */
+    color: white;
+    padding: 0.75rem 1.5rem;
+    border-radius: 5px;
+    font-weight: bold;
+    text-decoration: none;
+    font-size: 1.25rem;
+    transition: background-color 0.3s ease;
+}
+
+.line-navbar-login:hover {
+    background-color: #00B000;
+}
+
+/* レスポンシブ対応 */
+@media (max-width: 768px) {
+    .line-profile-edit-form {
+        padding: 2.5rem;
+    }
+
+    .line-top-explanation h3 {
+        font-size: 1.5rem;
+    }
+
+    .line-navbar-login {
+        font-size: 1.1rem;
+        padding: 0.6rem 1.2rem;
+    }
+}
+
+@media (max-width: 576px) {
+    .line-profile-edit-form {
+        padding: 2rem;
+    }
+
+    .line-top-explanation h3 {
+        font-size: 1.25rem;
+    }
+
+    .line-navbar-login {
+        font-size: 1rem;
+        padding: 0.5rem 1rem;
+    }
+}

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,4 +3,5 @@ skip_before_action :require_login, only: %i[terms privacy]
 
   def terms; end
   def privacy; end
+  def line; end
 end

--- a/app/jobs/line_bot.rb
+++ b/app/jobs/line_bot.rb
@@ -1,0 +1,23 @@
+class LineBot < ApplicationJob
+  require 'line/bot'
+
+  LINE_MESSAGE = "今日は何を食べますか。\n↓↓をクリック\nhttps://today-menu.onrender.com/menus/suggest"
+
+  def initialize
+    @client = Line::Bot::Client.new { |config|
+      config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
+      config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
+    }
+  end
+
+  # def push_message(user_id, message)
+    # @client.push_message(user_id, {
+      # type: 'text',
+      # text: LINE_MESSAGE
+    # })
+  # end
+
+  def broadcast_message
+    @client.broadcast({ type: 'text', text: LINE_MESSAGE })
+  end
+end

--- a/app/views/pages/line.html.erb
+++ b/app/views/pages/line.html.erb
@@ -1,0 +1,12 @@
+<% content_for(:title, t('.title')) %>
+<% breadcrumb :line_path %>
+<div class="line-profile-container">
+  <div class="line-profile-edit-form">
+    <div class="line-top-explanation">
+      <h3>友だち追加でLINEから献立をチェックできます！</h3>
+    </div>
+    <%= link_to 'https://page.line.me/463wwxxg', class: 'line-navbar-login' do %>
+      <i class="bi bi-line"></i> 友だち追加！
+    <% end %>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -10,7 +10,7 @@
           <%= link_to t('header.board'), new_menu_path, class: 'menu-item' %>
           <%= link_to t('header.board_index'), menus_path, class: 'menu-item' %>
           <%= link_to t('header.bookmark_index'), likes_menus_path, class: 'menu-item' %>
-          <%= link_to t('header.line'), '#', class: 'menu-item' %>
+          <%= link_to t('header.line'), line_path, class: 'menu-item' %>
           <%= link_to t('header.logout'), logout_path, class: 'menu-item', data: { turbo_method: :delete } %>
         </div>
       </div>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -47,6 +47,11 @@ crumb :edit_profile_path do
   parent :root
 end
 
+crumb :line_path do
+  link 'LINE通知', line_path
+  parent :root
+end
+
 # 投稿編集
 crumb :edit_menu_path do
   link '献立編集', edit_menu_path

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -82,7 +82,7 @@ ja:
     board: 献立投稿
     board_index: 投稿一覧
     bookmark_index: お気に入り一覧
-    line: LINE通知
+    line: LNE友だち追加
   footer:
     inquiry: お問い合わせ
     terms: 利用規約
@@ -92,6 +92,9 @@ ja:
       title: 利用規約
     privacy:
       title: プライバシーポリシー
+    line:
+      title: LNE友だち追加
+      frend: 友達登録！
   profiles:
     edit:
       title: 会員情報編集

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
 
   get 'terms', to: 'pages#terms'
   get 'privacy', to: 'pages#privacy'
+  get 'line', to: 'pages#line'
 
   resources :users, only: %i[new create destroy]
   get 'login', to: 'user_sessions#new'


### PR DESCRIPTION
# 概要
closes #31 
closes #32 

ログイン後のLINE友達追加ページを追加しました。
LINE通知機能はLINE通知を鬱陶しく思うユーザーに配慮し、APIを用いた通知は行わないことにしました。

「今日何食べる？」とユーザーが送信することで献立のurlを送信する仕組みになっています。